### PR TITLE
Update dependencies, including stable pin-project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-tower"
-version = "0.2.0-alpha.1"
+version = "0.2.0-alpha.2"
 edition = "2018"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 
@@ -26,16 +26,30 @@ tower-load = "=0.3.0-alpha.1"
 futures-util-preview = "=0.3.0-alpha.18"
 futures-core-preview = "=0.3.0-alpha.18"
 futures-sink-preview = "=0.3.0-alpha.18"
-tokio-executor = "=0.2.0-alpha.4"
-tokio-sync = "=0.2.0-alpha.4"
+tokio-executor = "=0.2.0-alpha.5"
+tokio-sync = "=0.2.0-alpha.5"
 crossbeam = "0.7"
 tracing = { version = "0.1.2", optional = true }
-pin-project = "0.4.0-alpha.11"
+pin-project = "0.4.0"
 
 [dev-dependencies]
-tokio = "=0.2.0-alpha.4"
+tokio = "=0.2.0-alpha.5"
 serde = "1.0"
 serde_derive = "1.0"
-async-bincode = "0.5.0-alpha.2"
+async-bincode = "=0.5.0-alpha.5"
 slab = "0.4"
-tokio-test = "=0.2.0-alpha.4"
+tokio-test = "=0.2.0-alpha.5"
+
+[patch.crates-io]
+tokio = { git = "https://github.com/tokio-rs/tokio" }
+tokio-codec = { git = "https://github.com/tokio-rs/tokio" }
+tokio-executor = { git = "https://github.com/tokio-rs/tokio" }
+tokio-fs = { git = "https://github.com/tokio-rs/tokio" }
+tokio-io = { git = "https://github.com/tokio-rs/tokio" }
+tokio-macros = { git = "https://github.com/tokio-rs/tokio" }
+tokio-net = { git = "https://github.com/tokio-rs/tokio" }
+tokio-sync = { git = "https://github.com/tokio-rs/tokio" }
+tokio-timer = { git = "https://github.com/tokio-rs/tokio" }
+tower-discover = { git = "https://github.com/taiki-e/tower.git", branch = "pin-project" }
+tower-service = { git = "https://github.com/taiki-e/tower.git", branch = "pin-project" }
+tower-load = { git = "https://github.com/taiki-e/tower.git", branch = "pin-project" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,35 +21,21 @@ log = ["tracing/log"]
 default = ["tracing"]
 
 [dependencies]
-tower-service = "=0.3.0-alpha.1"
-tower-load = "=0.3.0-alpha.1"
-futures-util-preview = "=0.3.0-alpha.18"
-futures-core-preview = "=0.3.0-alpha.18"
-futures-sink-preview = "=0.3.0-alpha.18"
-tokio-executor = "=0.2.0-alpha.5"
-tokio-sync = "=0.2.0-alpha.5"
+tower-service = "=0.3.0-alpha.2"
+tower-load = "=0.3.0-alpha.2"
+futures-util-preview = "=0.3.0-alpha.19"
+futures-core-preview = "=0.3.0-alpha.19"
+futures-sink-preview = "=0.3.0-alpha.19"
+tokio-executor = "=0.2.0-alpha.6"
+tokio-sync = "=0.2.0-alpha.6"
 crossbeam = "0.7"
 tracing = { version = "0.1.2", optional = true }
 pin-project = "0.4.0"
 
 [dev-dependencies]
-tokio = "=0.2.0-alpha.5"
+tokio = "=0.2.0-alpha.6"
 serde = "1.0"
 serde_derive = "1.0"
-async-bincode = "=0.5.0-alpha.5"
+async-bincode = "0.5.0-alpha.3"
 slab = "0.4"
-tokio-test = "=0.2.0-alpha.5"
-
-[patch.crates-io]
-tokio = { git = "https://github.com/tokio-rs/tokio" }
-tokio-codec = { git = "https://github.com/tokio-rs/tokio" }
-tokio-executor = { git = "https://github.com/tokio-rs/tokio" }
-tokio-fs = { git = "https://github.com/tokio-rs/tokio" }
-tokio-io = { git = "https://github.com/tokio-rs/tokio" }
-tokio-macros = { git = "https://github.com/tokio-rs/tokio" }
-tokio-net = { git = "https://github.com/tokio-rs/tokio" }
-tokio-sync = { git = "https://github.com/tokio-rs/tokio" }
-tokio-timer = { git = "https://github.com/tokio-rs/tokio" }
-tower-discover = { git = "https://github.com/taiki-e/tower.git", branch = "pin-project" }
-tower-service = { git = "https://github.com/taiki-e/tower.git", branch = "pin-project" }
-tower-load = { git = "https://github.com/taiki-e/tower.git", branch = "pin-project" }
+tokio-test = "=0.2.0-alpha.6"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ stages:
      - template: azure/cargo-check.yml@templates
        parameters:
          name: cargo_check
-         rust: nightly
+         rust: beta
  - stage: test
    displayName: Test suite
    dependsOn: check
@@ -14,7 +14,11 @@ stages:
      - template: azure/test.yml@templates
        parameters:
          cross: true
+         rust: beta
+     - template: azure/test.yml@templates
+       parameters:
          rust: nightly
+         allow_fail: true
  - stage: style
    displayName: Style linting
    dependsOn: check
@@ -22,12 +26,12 @@ stages:
      - template: azure/rustfmt.yml@templates
        parameters:
          name: rustfmt
-         rust: nightly
+         rust: beta
          allow_fail: true
      - template: azure/cargo-clippy.yml@templates
        parameters:
          name: clippy
-         rust: nightly
+         rust: beta
          allow_fail: true
 
 resources:

--- a/src/multiplex/client.rs
+++ b/src/multiplex/client.rs
@@ -202,7 +202,7 @@ where
 {
     type Output = Result<(), E>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         // go through the deref so we can do partial borrows
         let this = self.project();
 

--- a/src/multiplex/mod.rs
+++ b/src/multiplex/mod.rs
@@ -48,16 +48,16 @@ where
 {
     type Error = <T as Sink<Request>>::Error;
 
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         self.project().transport.poll_ready(cx)
     }
-    fn start_send(mut self: Pin<&mut Self>, item: Request) -> Result<(), Self::Error> {
+    fn start_send(self: Pin<&mut Self>, item: Request) -> Result<(), Self::Error> {
         self.project().transport.start_send(item)
     }
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         self.project().transport.poll_flush(cx)
     }
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         self.project().transport.poll_close(cx)
     }
 }
@@ -67,7 +67,7 @@ where
     T: TryStream,
 {
     type Item = Result<<T as TryStream>::Ok, <T as TryStream>::Error>;
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         self.project().transport.try_poll_next(cx)
     }
 }
@@ -78,10 +78,10 @@ where
     S: TagStore<Request, <T as TryStream>::Ok>,
 {
     type Tag = <S as TagStore<Request, <T as TryStream>::Ok>>::Tag;
-    fn assign_tag(mut self: Pin<&mut Self>, req: &mut Request) -> Self::Tag {
+    fn assign_tag(self: Pin<&mut Self>, req: &mut Request) -> Self::Tag {
         self.project().tagger.assign_tag(req)
     }
-    fn finish_tag(mut self: Pin<&mut Self>, rsp: &<T as TryStream>::Ok) -> Self::Tag {
+    fn finish_tag(self: Pin<&mut Self>, rsp: &<T as TryStream>::Ok) -> Self::Tag {
         self.project().tagger.finish_tag(rsp)
     }
 }

--- a/src/multiplex/server.rs
+++ b/src/multiplex/server.rs
@@ -183,7 +183,7 @@ where
 {
     type Output = Result<(), Error<T, S>>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         // go through the deref so we can do partial borrows
         let this = self.project();
 

--- a/src/pipeline/client.rs
+++ b/src/pipeline/client.rs
@@ -179,7 +179,7 @@ where
 {
     type Output = Result<(), E>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         // go through the deref so we can do partial borrows
         let this = self.project();
 

--- a/src/pipeline/server.rs
+++ b/src/pipeline/server.rs
@@ -184,7 +184,7 @@ where
 {
     type Output = Result<(), Error<T, S>>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         // go through the deref so we can do partial borrows
         let this = self.project();
 

--- a/tests/pipeline/client.rs
+++ b/tests/pipeline/client.rs
@@ -19,11 +19,11 @@ async fn it_works() {
 
     tokio::spawn(async move {
         loop {
-            let (stream, _) = rx.accept().await.unwrap();
-            let (r, w) = stream.split();
-            let mut r: AsyncBincodeReader<_, Request> = AsyncBincodeReader::from(r);
-            let mut w: AsyncBincodeWriter<_, Response, _> = AsyncBincodeWriter::from(w).for_async();
+            let (mut stream, _) = rx.accept().await.unwrap();
             tokio::spawn(async move {
+                let (r, w) = stream.split();
+                let mut r: AsyncBincodeReader<_, Request> = AsyncBincodeReader::from(r);
+                let mut w: AsyncBincodeWriter<_, Response, _> = AsyncBincodeWriter::from(w).for_async();
                 loop {
                     let req = r.next().await.unwrap().unwrap();
                     w.send(Response::from(req)).await.unwrap();

--- a/tests/pipeline/client.rs
+++ b/tests/pipeline/client.rs
@@ -23,7 +23,8 @@ async fn it_works() {
             tokio::spawn(async move {
                 let (r, w) = stream.split();
                 let mut r: AsyncBincodeReader<_, Request> = AsyncBincodeReader::from(r);
-                let mut w: AsyncBincodeWriter<_, Response, _> = AsyncBincodeWriter::from(w).for_async();
+                let mut w: AsyncBincodeWriter<_, Response, _> =
+                    AsyncBincodeWriter::from(w).for_async();
                 loop {
                     let req = r.next().await.unwrap().unwrap();
                     w.send(Response::from(req)).await.unwrap();


### PR DESCRIPTION
Updates all futures-related dependencies to keep up with ecosystem changes. Also enables testing on beta now that async/await is there!