### PR TITLE
Do not panic on server desynchronization

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,9 @@ where
 
     /// Attempted to issue a `call`, but the underlying transport has been closed.
     ClientDropped,
+
+    /// The server sent a response that the client was not expecting.
+    Desynchronized,
 }
 
 impl<T, I> fmt::Display for Error<T, I>
@@ -37,6 +40,7 @@ where
             Error::BrokenTransportRecv(None) => f.pad("transport closed with in-flight requests"),
             Error::TransportFull => f.pad("no more in-flight requests allowed"),
             Error::ClientDropped => f.pad("Client was dropped"),
+            Error::Desynchronized => f.pad("server sent a response the client did not expect"),
         }
     }
 }
@@ -54,6 +58,7 @@ where
             Error::BrokenTransportRecv(None) => f.pad("BrokenTransportRecv"),
             Error::TransportFull => f.pad("TransportFull"),
             Error::ClientDropped => f.pad("ClientDropped"),
+            Error::Desynchronized => f.pad("Desynchronized"),
         }
     }
 }
@@ -80,6 +85,7 @@ where
             Error::BrokenTransportRecv(None) => "transport closed with in-flight requests",
             Error::TransportFull => "no more in-flight requests allowed",
             Error::ClientDropped => "Client was dropped",
+            Error::Desynchronized => "server sent a response the client did not expect",
         }
     }
 }

--- a/src/multiplex/client.rs
+++ b/src/multiplex/client.rs
@@ -324,7 +324,7 @@ where
                         .responses
                         .iter()
                         .position(|&Pending { ref tag, .. }| tag == &id)
-                        .expect("got a request with no sender?");
+                        .ok_or(Error::Desynchronized)?;
 
                     // this request just finished, which means it's _probably_ near the front
                     // (i.e., was issued a while ago). so, for the swap needed for efficient

--- a/src/pipeline/client.rs
+++ b/src/pipeline/client.rs
@@ -291,10 +291,7 @@ where
                 Some(r) => {
                     // ignore send failures
                     // the client may just no longer care about the response
-                    let pending = this
-                        .responses
-                        .pop_front()
-                        .expect("got a request with no sender?");
+                    let pending = this.responses.pop_front().ok_or(Error::Desynchronized)?;
                     tracing::trace!(parent: &pending.span, "response arrived; forwarding");
 
                     let sender = pending.tx;


### PR DESCRIPTION
Previously, we would panic if the server sends a response to a request
the client does not have a record of. With this change, it is up to the
user whether this should cause a panic or not. We raise it as a new
error, `Error::Desynchronized`, and the user can to panic in the error
handler if they so wish.

This is a backwards-incompatible change.

Fixes #15.