### PR TITLE
Impl source instead of cause for error::Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -69,10 +69,10 @@ where
     <T as Sink<I>>::Error: error::Error,
     <T as TryStream>::Error: error::Error,
 {
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
-            Error::BrokenTransportSend(ref se) => Some(se),
-            Error::BrokenTransportRecv(Some(ref se)) => Some(se),
+            Error::BrokenTransportSend(ref se) => se.source(),
+            Error::BrokenTransportRecv(Some(ref se)) => se.source(),
             _ => None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,8 +35,10 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Error::BrokenTransportSend(ref se) => fmt::Display::fmt(se, f),
-            Error::BrokenTransportRecv(Some(ref se)) => fmt::Display::fmt(se, f),
+            Error::BrokenTransportSend(_) => f.pad("underlying transport failed to send a request"),
+            Error::BrokenTransportRecv(Some(_)) => {
+                f.pad("underlying transport failed while attempting to receive a response")
+            }
             Error::BrokenTransportRecv(None) => f.pad("transport closed with in-flight requests"),
             Error::TransportFull => f.pad("no more in-flight requests allowed"),
             Error::ClientDropped => f.pad("Client was dropped"),
@@ -66,26 +68,14 @@ where
 impl<T, I> error::Error for Error<T, I>
 where
     T: Sink<I> + TryStream,
-    <T as Sink<I>>::Error: error::Error,
-    <T as TryStream>::Error: error::Error,
+    <T as Sink<I>>::Error: error::Error + 'static,
+    <T as TryStream>::Error: error::Error + 'static,
 {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
-            Error::BrokenTransportSend(ref se) => se.source(),
-            Error::BrokenTransportRecv(Some(ref se)) => se.source(),
+            Error::BrokenTransportSend(ref se) => Some(se),
+            Error::BrokenTransportRecv(Some(ref se)) => Some(se),
             _ => None,
-        }
-    }
-
-    #[allow(deprecated)]
-    fn description(&self) -> &str {
-        match *self {
-            Error::BrokenTransportSend(ref se) => se.description(),
-            Error::BrokenTransportRecv(Some(ref se)) => se.description(),
-            Error::BrokenTransportRecv(None) => "transport closed with in-flight requests",
-            Error::TransportFull => "no more in-flight requests allowed",
-            Error::ClientDropped => "Client was dropped",
-            Error::Desynchronized => "server sent a response the client did not expect",
         }
     }
 }

--- a/src/multiplex/client.rs
+++ b/src/multiplex/client.rs
@@ -445,10 +445,10 @@ impl<T> error::Error for SpawnError<T>
 where
     T: error::Error,
 {
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             SpawnError::SpawnFailed => None,
-            SpawnError::Inner(ref te) => Some(te),
+            SpawnError::Inner(ref te) => te.source(),
         }
     }
 

--- a/src/multiplex/client.rs
+++ b/src/multiplex/client.rs
@@ -433,26 +433,20 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            SpawnError::SpawnFailed => write!(f, "error spawning multiplex client"),
-            SpawnError::Inner(ref te) => {
-                write!(f, "error making new multiplex transport: {:?}", te)
-            }
+            SpawnError::SpawnFailed => f.pad("error spawning multiplex client"),
+            SpawnError::Inner(_) => f.pad("error making new multiplex transport"),
         }
     }
 }
 
 impl<T> error::Error for SpawnError<T>
 where
-    T: error::Error,
+    T: error::Error + 'static,
 {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             SpawnError::SpawnFailed => None,
-            SpawnError::Inner(ref te) => te.source(),
+            SpawnError::Inner(ref te) => Some(te),
         }
-    }
-
-    fn description(&self) -> &str {
-        "error creating new multiplex client"
     }
 }

--- a/src/multiplex/server.rs
+++ b/src/multiplex/server.rs
@@ -88,11 +88,11 @@ where
     <T as TryStream>::Error: error::Error,
     S::Error: error::Error,
 {
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
-            Error::BrokenTransportSend(ref se) => Some(se),
-            Error::BrokenTransportRecv(ref se) => Some(se),
-            Error::Service(ref se) => Some(se),
+            Error::BrokenTransportSend(ref se) => se.source(),
+            Error::BrokenTransportRecv(ref se) => se.source(),
+            Error::Service(ref se) => se.source(),
         }
     }
 

--- a/src/pipeline/client.rs
+++ b/src/pipeline/client.rs
@@ -393,26 +393,20 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            SpawnError::SpawnFailed => write!(f, "error spawning multiplex client"),
-            SpawnError::Inner(ref te) => {
-                write!(f, "error making new multiplex transport: {:?}", te)
-            }
+            SpawnError::SpawnFailed => f.pad("error spawning multiplex client"),
+            SpawnError::Inner(_) => f.pad("error making new multiplex transport"),
         }
     }
 }
 
 impl<T> error::Error for SpawnError<T>
 where
-    T: error::Error,
+    T: error::Error + 'static,
 {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             SpawnError::SpawnFailed => None,
-            SpawnError::Inner(ref te) => te.source(),
+            SpawnError::Inner(ref te) => Some(te),
         }
-    }
-
-    fn description(&self) -> &str {
-        "error creating new multiplex client"
     }
 }

--- a/src/pipeline/client.rs
+++ b/src/pipeline/client.rs
@@ -405,10 +405,10 @@ impl<T> error::Error for SpawnError<T>
 where
     T: error::Error,
 {
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             SpawnError::SpawnFailed => None,
-            SpawnError::Inner(ref te) => Some(te),
+            SpawnError::Inner(ref te) => te.source(),
         }
     }
 

--- a/src/pipeline/server.rs
+++ b/src/pipeline/server.rs
@@ -88,11 +88,11 @@ where
     <T as TryStream>::Error: error::Error,
     S::Error: error::Error,
 {
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
-            Error::BrokenTransportSend(ref se) => Some(se),
-            Error::BrokenTransportRecv(ref se) => Some(se),
-            Error::Service(ref se) => Some(se),
+            Error::BrokenTransportSend(ref se) => se.source(),
+            Error::BrokenTransportRecv(ref se) => se.source(),
+            Error::Service(ref se) => se.source(),
         }
     }
 


### PR DESCRIPTION
Switch from `cause` to `source` method for `std::error::Error` impls.