### PR TITLE
Fix connection leak when try_poll_next mutates the pending store

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
  - template: default.yml@templates
    parameters:
-     minrust: 1.52
+     minrust: 1.56
 
 resources:
   repositories:


### PR DESCRIPTION
This change solves a bug where the multiplexing client could leak both connections and memory.

For transports where `poll_next` mutates the pending store, the multiplexing client could end up leaking the file connection file descriptor as the `ClientInner` would never complete even though the `multiplex::Client`
 has been dropped.

An example of this would be a UDP-based transport where the application implements per-request timeouts to clean up the pending store if the server never replies within `poll_next`. When the application decides to drop the connection and if there is still an inflight request which has timed out, the `ClientInner` would never complete.