### PR TITLE
fix(docs/lib): Correctly qualify Sink in example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@
 //!     snd: mpsc::UnboundedSender<T>,
 //! }
 //!
-//! impl<T: Debug> futures_sink::Sink<T> for ChannelTransport<T> {
+//! impl<T: Debug> futures_util::sink::Sink<T> for ChannelTransport<T> {
 //!     type Error = StdError;
 //!
 //!     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {


### PR DESCRIPTION
Use futures_util::sink::Sink instead of futures_sink::Sink.